### PR TITLE
fix: ci/cd goreleaser and unnamed workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ on: workflow_call
 
 jobs:
   build-and-test:
+    name: Build and Test
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           go-version: 1.19
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser
           version: latest


### PR DESCRIPTION
- feat: give name `Build and Test` to ci workflow instead of just using `build-and-test`
- bump version goreleaser to v4